### PR TITLE
Ignore commands

### DIFF
--- a/Plugin/src/AutoPatches.cs
+++ b/Plugin/src/AutoPatches.cs
@@ -29,7 +29,7 @@ public class Patches
     [HarmonyPostfix]
     public static void AddPlayerChatMessageClientRpcPostfix(HUDManager __instance, string chatMessage, int playerId)
     {
-        if (lastChatMessage == chatMessage)
+        if (lastChatMessage == chatMessage || chatMessage.StartsWith("/"))
         {
             return;
         }


### PR DESCRIPTION
This pull request makes the TTS ignore commands starting with a forward slash (`/`). 

This is used by some plugins like [Boombox controller](https://thunderstore.io/c/lethal-company/p/KoderTeh/Boombox_Controller/)