### PR TITLE
Thread safety fix

### DIFF
--- a/Plugin/src/AutoPatches.cs
+++ b/Plugin/src/AutoPatches.cs
@@ -5,13 +5,10 @@ using GameNetcodeStuff;
 using System.Linq;
 using TMPro;
 using UnityEngine;
-using Dissonance.Integrations.Unity_NFGO;
 using System.Collections;
 using System.Threading.Tasks;
 using System;
 using System.Reflection;
-
-
 
 namespace AEIOU_Company;
 
@@ -22,8 +19,8 @@ public class Patches
     private static TMP_InputField chatTextField = null;
     private static string lastChatMessage = "";
     private static readonly float[] emptySamples = new float[TTS.IN_BUFFER_SIZE];
-    private static List<Speak> _speaks = new List<Speak>();
-    private static bool _isProcessing = false;
+    private static readonly List<Speak> pendingSpeech = new List<Speak>();
+    private static Task<TTS.SpeechData> currentSpeechTask = null;
 
     [HarmonyPatch(typeof(HUDManager), "AddPlayerChatMessageClientRpc")]
     [HarmonyPostfix]
@@ -47,162 +44,157 @@ public class Patches
 		}
 
         Plugin.Log($"AddTextToChatOnServer: {chatMessage} {playerId}");
-        QueueSpeak(__instance, chatMessage, playerId);
+        Speak(__instance, chatMessage, playerId);
+    }
 
-        if (_isProcessing)
+    [HarmonyPatch(typeof(HUDManager), "Update")]
+    [HarmonyPostfix]
+    public static void UpdatePostfix(HUDManager __instance)
+    {
+        if (currentSpeechTask != null)
         {
-            return;
-        }
-        _isProcessing = true;
-        Task.Run(() =>
-        {
-            while (_speaks.Count > 0)
+            if (!currentSpeechTask.IsCompleted) { return; }
+
+            if (!currentSpeechTask.IsCanceled && !currentSpeechTask.IsFaulted)
             {
-                try
+                var playerId = currentSpeechTask.Result.PlayerId;
+                PlayerControllerB player = __instance.playersManager.allPlayerScripts[playerId];
+                if (player == null)
                 {
-                    Speak(__instance, _speaks[0].ChatMessage, _speaks[0].PlayerId);
-                    _speaks.RemoveAt(0);
-                }
-                catch (Exception e)
-                {
-                    Plugin.Log(e);
-                    _speaks.Clear();
-                    _isProcessing = false;
+                    Plugin.Log("couldnt find player");
                     return;
                 }
+
+                Plugin.Log("Found player");
+
+                GameObject AEIOUSpeakObject = player.gameObject.transform.Find("AEIOUSpeakObject")?.gameObject;
+                if (AEIOUSpeakObject == null)
+                {
+                    AEIOUSpeakObject = new GameObject("AEIOUSpeakObject");
+                    AEIOUSpeakObject.transform.parent = player.transform;
+                    AEIOUSpeakObject.transform.localPosition = Vector3.zero;
+                    AEIOUSpeakObject.AddComponent<AudioSource>();
+                    AEIOUSpeakObject.AddComponent<AudioHighPassFilter>();
+                    AEIOUSpeakObject.AddComponent<AudioLowPassFilter>();
+                }
+
+                Plugin.Log("Found AEIOUSpeakObject");
+                AudioSource audioSource = AEIOUSpeakObject.GetComponent<AudioSource>();
+                if (audioSource == null)
+                {
+                    Plugin.LogError($"Couldn't speak, AudioSource was null");
+                    return;
+                }
+
+                if (audioSource.clip == null)
+                {
+                    audioSource.clip = AudioClip.Create("AEIOUCLIP", TTS.IN_BUFFER_SIZE, 1, 11025, false);
+                }
+
+                Plugin.Log("Setting up clip");
+                audioSource.clip.SetData(emptySamples, 0);
+                audioSource.clip.SetData(currentSpeechTask.Result.AudioData, 0);
+
+                audioSource.outputAudioMixerGroup = SoundManager.Instance.playerVoiceMixers[player.playerClientId];
+                audioSource.playOnAwake = false;
+                audioSource.rolloffMode = AudioRolloffMode.Custom;
+                audioSource.minDistance = 1f;
+                audioSource.maxDistance = 40f;
+                audioSource.dopplerLevel = Plugin.TTSDopperLevel;
+                audioSource.pitch = 1f;
+                audioSource.spatialize = true;
+                audioSource.spatialBlend = player.isPlayerDead ? 0f : 1f;
+                bool playerHasDeathPermissions =
+                    !player.isPlayerDead || StartOfRound.Instance.localPlayerController.isPlayerDead;
+                audioSource.volume = playerHasDeathPermissions ? Plugin.TTSVolume : 0;
+
+                AudioHighPassFilter highPassFilter = AEIOUSpeakObject.GetComponent<AudioHighPassFilter>();
+                if (highPassFilter != null)
+                {
+                    highPassFilter.enabled = false;
+                }
+
+                AudioLowPassFilter lowPassFilter = AEIOUSpeakObject.GetComponent<AudioLowPassFilter>();
+                if (lowPassFilter != null)
+                {
+                    lowPassFilter.lowpassResonanceQ = 1;
+                    lowPassFilter.cutoffFrequency = 5000;
+                }
+
+                if (audioSource.isPlaying)
+                {
+                    audioSource.Stop(true);
+                }
+
+                Plugin.Log
+                (
+                    $"Playing audio: {audioSource.ToString()}" + audioSource.volume.ToString()
+                );
+                if (player.holdingWalkieTalkie && player.currentlyHeldObjectServer is WalkieTalkie walkieTalkie)
+                {
+                    Plugin.Log("WalkieTalkie");
+                    bool localPlayerIsUsingWalkieTalkie = false;
+                    for (int i = 0; i < WalkieTalkie.allWalkieTalkies.Count; i++)
+                    {
+                        if
+                        (
+                            WalkieTalkie.allWalkieTalkies[i].playerHeldBy == StartOfRound.Instance.localPlayerController
+                            && WalkieTalkie.allWalkieTalkies[i].isBeingUsed
+                        )
+                        {
+                            localPlayerIsUsingWalkieTalkie = true;
+                        }
+                    }
+
+                    if
+                    (
+                        walkieTalkie != null
+                        && walkieTalkie.isBeingUsed
+                        && localPlayerIsUsingWalkieTalkie
+                    )
+                    {
+                        audioSource.volume = Plugin.TTSVolume;
+                        if (player == StartOfRound.Instance.localPlayerController)
+                        {
+                            Plugin.Log("Pushing walkie button");
+                            player.playerBodyAnimator.SetBool("walkieTalkie", true);
+                            walkieTalkie.StartCoroutine(WaitAndStopUsingWalkieTalkie(audioSource.clip, player, currentSpeechTask.Result.AudioLengthInSeconds));
+                        }
+                        else
+                        {
+                            highPassFilter.enabled = true;
+                            lowPassFilter.lowpassResonanceQ = 3f;
+                            lowPassFilter.cutoffFrequency = 4000;
+                            audioSource.spatialBlend = 0f;
+                        }
+                    }
+                }
+
+                audioSource.PlayOneShot(audioSource.clip, 1f);
+                RoundManager.Instance.PlayAudibleNoise(AEIOUSpeakObject.transform.position, 25f, 0.7f);
             }
-            _isProcessing = false;
-        });
+
+            currentSpeechTask = null;
+        }
+
+        if (pendingSpeech.Count > 0)
+        {
+            var nextSpeech = pendingSpeech[0];
+            pendingSpeech.RemoveAt(0);
+            currentSpeechTask = Task.Run(() => TTS.SpeakToMemory(nextSpeech.PlayerId, nextSpeech.ChatMessage, 7.5f));
+        }
     }
-    public static void Speak(HUDManager __instance, string chatMessage, int playerId)
+
+    private static void Speak(HUDManager __instance, string chatMessage, int playerId)
     {
         Plugin.Log("Speak");
-        PlayerControllerB player = null;
-        for (int i = 0; i < __instance.playersManager.allPlayerScripts.Length; i++)
-        {
-            if (__instance.playersManager.allPlayerScripts[playerId])
-            {
-                player = __instance.playersManager.allPlayerScripts[playerId];
-            }
-        }
-        if (player == null)
-        {
-            Plugin.Log("couldnt find player");
-            return;
-        }
-        Plugin.Log("Found player");
-
-        GameObject AEIOUSpeakObject = player.gameObject.transform.Find("AEIOUSpeakObject")?.gameObject;
-        if (AEIOUSpeakObject == null)
-        {
-            AEIOUSpeakObject = new GameObject("AEIOUSpeakObject");
-            AEIOUSpeakObject.transform.parent = player.transform;
-            AEIOUSpeakObject.transform.localPosition = Vector3.zero;
-            AEIOUSpeakObject.AddComponent<AudioSource>();
-            AEIOUSpeakObject.AddComponent<AudioHighPassFilter>();
-            AEIOUSpeakObject.AddComponent<AudioLowPassFilter>();
-        }
-        Plugin.Log("Found AEIOUSpeakObject");
-        AudioSource audioSource = AEIOUSpeakObject.GetComponent<AudioSource>();
-        if (audioSource == null)
-        {
-            Plugin.LogError($"Couldn't speak, AudioSource was null");
-            return;
-        }
-        string filteredChatMessage = chatMessage.Replace("\r", "").Replace("\n", "");
-        float[] samples = TTS.SpeakToMemory(filteredChatMessage, 7.5f);
-        if (audioSource.clip == null)
-        {
-            audioSource.clip = AudioClip.Create("AEIOUCLIP", TTS.IN_BUFFER_SIZE, 1, 11025, false);
-        }
-        Plugin.Log("Setting up clip");
-        audioSource.clip.SetData(emptySamples, 0);
-        audioSource.clip.SetData(samples, 0);
-
-        audioSource.outputAudioMixerGroup = SoundManager.Instance.playerVoiceMixers[player.playerClientId];
-        audioSource.playOnAwake = false;
-        audioSource.rolloffMode = AudioRolloffMode.Custom;
-        audioSource.minDistance = 1f;
-        audioSource.maxDistance = 40f;
-        audioSource.dopplerLevel = Plugin.TTSDopperLevel;
-        audioSource.pitch = 1f;
-        audioSource.spatialize = true;
-        audioSource.spatialBlend = player.isPlayerDead ? 0f : 1f;
-        bool playerHasDeathPermissions = !player.isPlayerDead || StartOfRound.Instance.localPlayerController.isPlayerDead;
-        audioSource.volume = playerHasDeathPermissions ? Plugin.TTSVolume : 0;
-
-        AudioHighPassFilter highPassFilter = AEIOUSpeakObject.GetComponent<AudioHighPassFilter>();
-        if (highPassFilter != null)
-        {
-            highPassFilter.enabled = false;
-        }
-
-        AudioLowPassFilter lowPassFilter = AEIOUSpeakObject.GetComponent<AudioLowPassFilter>();
-        if (lowPassFilter != null)
-        {
-            lowPassFilter.lowpassResonanceQ = 1;
-            lowPassFilter.cutoffFrequency = 5000;
-        }
-
-        if (audioSource.isPlaying)
-        {
-            audioSource.Stop(true);
-        }
-
-        Plugin.Log
-        (
-            $"Playing audio: {audioSource.ToString()}" + audioSource.volume.ToString()
-        );
-        if (player.holdingWalkieTalkie && player.currentlyHeldObjectServer is WalkieTalkie walkieTalkie)
-        {
-            Plugin.Log("WalkieTalkie");
-            bool localPlayerIsUsingWalkieTalkie = false;
-            for (int i = 0; i < WalkieTalkie.allWalkieTalkies.Count; i++)
-            {
-                if
-                (
-                    WalkieTalkie.allWalkieTalkies[i].playerHeldBy == StartOfRound.Instance.localPlayerController
-                    && WalkieTalkie.allWalkieTalkies[i].isBeingUsed
-                )
-                {
-                    localPlayerIsUsingWalkieTalkie = true;
-                }
-            }
-            if
-            (
-                walkieTalkie != null
-                && walkieTalkie.isBeingUsed
-                && localPlayerIsUsingWalkieTalkie
-            )
-            {
-                audioSource.volume = Plugin.TTSVolume;
-                if (player == StartOfRound.Instance.localPlayerController)
-                {
-                    Plugin.Log("Pushing walkie button");
-                    player.playerBodyAnimator.SetBool("walkieTalkie", true);
-                    walkieTalkie.StartCoroutine(WaitAndStopUsingWalkieTalkie(audioSource.clip, player));
-                }
-                else
-                {
-                    highPassFilter.enabled = true;
-                    lowPassFilter.lowpassResonanceQ = 3f;
-                    lowPassFilter.cutoffFrequency = 4000;
-                    audioSource.spatialBlend = 0f;
-                }
-            }
-        }
-        audioSource.PlayOneShot(audioSource.clip, 1f);
-        RoundManager.Instance.PlayAudibleNoise(AEIOUSpeakObject.transform.position, 25f, 0.7f);
+        pendingSpeech.Add(new Speak(chatMessage, playerId));
     }
-    public static void QueueSpeak(HUDManager __instance, string chatMessage, int playerId)
+
+    private static IEnumerator WaitAndStopUsingWalkieTalkie(AudioClip clip, PlayerControllerB player, float audioLengthInSeconds)
     {
-        Plugin.Log("Queueing speak");
-        _speaks.Add(new Speak(chatMessage, playerId));
-    }
-    public static IEnumerator WaitAndStopUsingWalkieTalkie(AudioClip clip, PlayerControllerB player)
-    {
-        Plugin.Log($"WalkieButton Length {TTS.CurrentAudioLengthInSeconds}");
-        yield return new WaitForSeconds(TTS.CurrentAudioLengthInSeconds);
+        Plugin.Log($"WalkieButton Length {audioLengthInSeconds}");
+        yield return new WaitForSeconds(audioLengthInSeconds);
         Plugin.Log($"WalkieButton end");
         player.playerBodyAnimator.SetBool("walkieTalkie", false);
     }
@@ -215,6 +207,7 @@ public class Patches
         chatTextField = ___chatTextField;
         Plugin.Log("Enable Chat");
     }
+
     [HarmonyPatch(typeof(PlayerControllerB), nameof(PlayerControllerB.KillPlayer))]
     [HarmonyPostfix]
     public static void KillPlayerPostfix(PlayerControllerB __instance)

--- a/Plugin/src/Speak.cs
+++ b/Plugin/src/Speak.cs
@@ -1,7 +1,7 @@
-public class Speak 
+public readonly struct Speak
 {
-    public string ChatMessage;
-    public int PlayerId;
+    public readonly string ChatMessage;
+    public readonly int PlayerId;
     public Speak(string chatMessage, int playerId)
     {
         ChatMessage = chatMessage;


### PR DESCRIPTION
Some of my friends noticed that the game was considerably less stable when AEIOUCompany was installed. I've managed to collect a lot of logs that end when someone sends a message in text chat and the mod plays back the sound for it:

```
[Info   :AEIOUCompany] Queueing speak
[Info   :AEIOUCompany] Speak
[Info   :AEIOUCompany] Found player
[Info   :AEIOUCompany] Found AEIOUSpeakObject
[Info   :AEIOUCompany] Sending: msg=hot damn]
[Info   :AEIOUCompany] END
[Info   :AEIOUCompany] Setting up clip
[Info   :AEIOUCompany] Playing audio: AEIOUSpeakObject (UnityEngine.AudioSource)1
```

I took a look at the code and noticed that the Task that is spawned to communicate with SpeakServer also interacts with the engine's audio system, which I understand to not be thread-safe. I suspect the reason a Task is used is to make the game not freeze due to slow communication with SpeakServer.

This PR changes how this works to instead wait for the Task to end and then prepare and play back the sound on the main thread. This appears to have improved stability, friends have played an hour-long session without issue.